### PR TITLE
Do not show memory reader's buffer in inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
 
+## 1.0.0
+* We no longer include the database's buffer in inspect output. This avoids
+  showing excessive output when creating a memory reader in irb. Reported
+  by Wojciech Wnętrzak. GitHub #6.
+
 ## 1.0.0.beta - 2018-12-24
 * Initial implementation.

--- a/lib/maxmind/db/memory_reader.rb
+++ b/lib/maxmind/db/memory_reader.rb
@@ -14,6 +14,12 @@ module MaxMind # :nodoc:
 
       attr_reader :size
 
+      # Override to not show @buf in inspect to avoid showing it in irb.
+      def inspect
+        s = "#<#{self.class.name}:0x#{self.class.object_id.to_s(16)} "
+        s << '@size=' << @size.inspect << '>'
+      end
+
       def close; end
 
       def read(offset, size)


### PR DESCRIPTION
This would cause the database's buffer to show when creating a reader of
this type in irb.

Fixes #6.