### PR TITLE
Fix FrozenError in MaxMind::DB::MemoryReader#inspect.

### DIFF
--- a/lib/maxmind/db/memory_reader.rb
+++ b/lib/maxmind/db/memory_reader.rb
@@ -19,8 +19,7 @@ module MaxMind
 
       # Override to not show @buf in inspect to avoid showing it in irb.
       def inspect
-        s = "#<#{self.class.name}:0x#{self.class.object_id.to_s(16)} "
-        s << '@size=' << @size.inspect << '>'
+        "#<#{self.class.name}:0x#{self.class.object_id.to_s(16)} @size={@size.inspect}>"
       end
 
       def close; end

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -29,6 +29,19 @@ class ReaderTest < Minitest::Test
     end
   end
 
+  def test_reader_inspect
+    modes = [
+      MaxMind::DB::MODE_FILE,
+      MaxMind::DB::MODE_MEMORY,
+    ]
+
+    modes.each do |mode|
+      filename = 'test/data/test-data/MaxMind-DB-test-ipv4-24.mmdb'
+      reader = MaxMind::DB.new(filename, mode: mode)
+      assert_instance_of(String, reader.inspect)
+    end
+  end
+
   def test_get_with_prefix_len
     decoder_record = {
       'array' => [1, 2, 3],


### PR DESCRIPTION
`MaxMind::DB::MemoryReader#inspect` crashes with `FrozenError`
because it calls `<<` on string literal and the file is marked as `frozen_string_literal: true`.

```
irb(main):001:0> MaxMind::DB.new('/path/to/GeoLite2-City.mmdb', mode: MaxMind::DB::MODE_MEMORY).inspect
Traceback (most recent call last):
        2: from (irb):1
        1: from (irb):1:in `inspect'
FrozenError (can't modify frozen String)
```
