### PR TITLE
CI: Rely on installed bundler; drop EOL'd 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7
-
-before_install:
-  - gem update --system
-  - gem install bundler
 
 notifications:
   email:


### PR DESCRIPTION
This PR attempts to simplify the configuration of CI.