### PR TITLE
Appease Rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 /doc
 /.yardoc
+Gemfile.lock
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,6 @@ Style/TrailingCommaInArrayLiteral:
     Enabled: false
 Style/TrailingCommaInHashLiteral:
     Enabled: false
+
+Gemspec/DevelopmentDependencies:
+    Enabled: false

--- a/lib/maxmind/db.rb
+++ b/lib/maxmind/db.rb
@@ -273,7 +273,7 @@ module MaxMind
     end
 
     def find_metadata_start
-      metadata_max_size = @size < METADATA_MAX_SIZE ? @size : METADATA_MAX_SIZE
+      metadata_max_size = [@size, METADATA_MAX_SIZE].min
 
       stop_index = @size - metadata_max_size
       index = @size - METADATA_START_MARKER_LENGTH


### PR DESCRIPTION
Fixes:

```
Offenses:

lib/maxmind/db.rb:276:27: C: [Correctable] Style/MinMaxComparison: Use [@size, METADATA_MAX_SIZE].min instead.
      metadata_max_size = @size < METADATA_MAX_SIZE ? @size : METADATA_MAX_SIZE
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
maxmind-db.gemspec:24:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  s.add_development_dependency 'minitest'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
maxmind-db.gemspec:25:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  s.add_development_dependency 'rake'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
maxmind-db.gemspec:26:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  s.add_development_dependency 'rubocop'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
maxmind-db.gemspec:27:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  s.add_development_dependency 'rubocop-performance'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```